### PR TITLE
docs: CI/CD를 위해 암호화 누락 경고 삭제

### DIFF
--- a/ToucheeseMVP/ToucheeseMVP/Resources/Info.plist
+++ b/ToucheeseMVP/ToucheeseMVP/Resources/Info.plist
@@ -15,6 +15,8 @@
 	</array>
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<false/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>KAKAO_NATIVE_APPKEY</key>
 	<string>$(KAKAO_NATIVE_APPKEY)</string>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
### 이슈 번호
- close: #

### 🔴 작업 유형

- [ ] feat: 신규 기능 추가
- [ ] fix: 버그 수정
- [ ] refactor: 리펙토링
- [ ] style: 간단한 주석 및 폴더 구조 정리
- [x] docs: 문서 업데이트

<br>

### 🔵 작업 내용

> 구현 내용 및 작업 했던 내용 (구체적으로 어떤 View, 어떤 기능 작업했는지)

- [x] CI/CD를 위해 암호화 누락 경고 삭제

<br>

### 📋 체크리스트

- [x] 내 코드에 오류가 없는지 검토했나요?
- [x] Merge 하는 브랜치가 올바른가요?
- [x] 코딩 컨벤션을 어기진 않았나요?

<br>

### 📝 PR 특이 사항

> PR에서 주의깊게 봐야하거나 말하고 싶은 점

- 로컬에서는 fastlane이 문제없이 동작한 것을 확인했습니다.
- Develop 브랜치에 머지 시 자동으로 테스트 플라이트 빌드가 올라가는 것을 확인했습니다. (약 5분 소요)
- 내부 그룹에 자동으로 빌드가 올라가는 것까지 설정했는데 적용되지 않아서 암호화 관련 경고 때문인 것 같아 설정해두었습니다.

### 아래는 이후 Fastlane을 세팅하기 위한 목록입니다.
- [x] Ruby 설치 (3.2.2)
- [x] Bundler 설치
- [ ] 경로 /ToucheeseMVP 에서 터미널로 bundle install 명령어 실행하기(Gemfile을 읽어서 fastlane 등 파일 실제 설치 과정)
- [ ] .env 파일 전달받아서 경로에 두기(경로 /ToucheeseMVP/fastlane - 깃에는 올라가면 안됩니다!)  