### PR TITLE
Fix/#142 문의 내역, 예약 내역을 불러오지 못하는 오류 수정

### DIFF
--- a/ToucheeseMVP/ToucheeseMVP/Service/Managers/AuthenticationManager.swift
+++ b/ToucheeseMVP/ToucheeseMVP/Service/Managers/AuthenticationManager.swift
@@ -92,22 +92,22 @@ final class AuthenticationManager: ObservableObject {
             return authStatus
         }
         
-        /// 토큰 재발행 요청, 실패 시 로그아웃 상태 리턴
-        guard let reissueTokenResponse = await requestReissueTokenToServer(refreshToken:tokens.refreshToken, deviceId: tokens.deviceId) else {
-            // Refresh 토큰이 만료된 경우 - 기존 데이터 삭제(로그아웃 처리)
-            await resetAllAuthDatas()
-            return authStatus
-        }
-        
-        /// reissueTokenResponse 헤더의 accessToken 접근
-        guard let accessToken = reissueTokenResponse.headers?["Authorization"]?.removeBearer else {
-            await failedAuthentication()
-            return authStatus
-        }
-                
-        // MARK: 로그인 상태
-        /// 계정 정보 업데이트
-        await updateAuthenticationInfo(reissueTokenResponse, accessToken)
+//        /// 토큰 재발행 요청, 실패 시 로그아웃 상태 리턴
+//        guard let reissueTokenResponse = await requestReissueTokenToServer(refreshToken:tokens.refreshToken, deviceId: tokens.deviceId) else {
+//            // Refresh 토큰이 만료된 경우 - 기존 데이터 삭제(로그아웃 처리)
+//            await resetAllAuthDatas()
+//            return authStatus
+//        }
+//        
+//        /// reissueTokenResponse 헤더의 accessToken 접근
+//        guard let accessToken = reissueTokenResponse.headers?["Authorization"]?.removeBearer else {
+//            await failedAuthentication()
+//            return authStatus
+//        }
+//                
+//        // MARK: 로그인 상태
+//        /// 계정 정보 업데이트
+//        await updateAuthenticationInfo(reissueTokenResponse, accessToken)
         
         /// 로그인 상태로 변경
         await successfulAuthentication()


### PR DESCRIPTION
### 이슈 번호
- closes: #142 

### 🔴 작업 유형

- [ ] feat: 신규 기능 추가
- [x] fix: 버그 수정
- [ ] refactor: 리펙토링
- [ ] style: 간단한 주석 및 폴더 구조 정리
- [ ] docs: 문서 업데이트

<br>

### 🔵 작업 내용

> 구현 내용 및 작업 했던 내용 (구체적으로 어떤 View, 어떤 기능 작업했는지)

- [x] 앱 실행 시 토큰 재발행 로직 주석 처리

<br>

### 📋 체크리스트

- [x] 내 코드에 오류가 없는지 검토했나요?
- [x] Merge 하는 브랜치가 올바른가요?
- [x] 코딩 컨벤션을 어기진 않았나요?

<br>

### 📝 PR 특이 사항

> PR에서 주의깊게 봐야하거나 말하고 싶은 점

토큰 문제임을 확인하고, 재발행 토큰과 `Session`의 `authenticator` 내부의 토큰이 일치하지 않아 생기는 문제로 예측하였습니다.
그래서 토큰 갱신 후 `Session`에 갱신된 토큰을 넣어주는 방향으로 해결하려 했으나, `authenticator` 로직은 재발행 토큰을 자동으로 Session에 다시 적용시켜주기 때문에 불필요한 작업이었습니다.  

진짜 오류의 원인이 되는 코드은 앱 최초 실행 시 토큰을 갱신하도록 되어있는 로직으로, `authenticator` 로직에 의해 갱신되지 않기 때문에 갱신된 토큰이 `authenticator` 적용되지 않기 때문에 해당 로직을 주석처리 하였습니다.

<br><br>
